### PR TITLE
Add target="_blank" to ProjectCard link

### DIFF
--- a/src/components/animations/ProjectCard.jsx
+++ b/src/components/animations/ProjectCard.jsx
@@ -12,6 +12,7 @@ const ProjectCard = ({ imgSrc, title, description, link_url, delay }) => (
     <div>
       <a
         href={link_url}
+        target="_blank"
         className="font-bold text-lg hover:text-[#FF0000] sm:text-xl"
       >
         {title}


### PR DESCRIPTION
Enable links in ProjectCard to open in a new tab for improved user experience.